### PR TITLE
Project name validation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <cctype>
 
 //Change when updating smith
 constexpr const char* SMITH_VERSION = "0.1.0";
@@ -21,6 +22,19 @@ void print_version() {
   std::cout << "smith version: " << SMITH_VERSION << std::endl;
 }
 
+bool is_valid_project_name(const std::string& name) {
+  if (name.empty() || name.size() > 64) {
+    return false;
+  }
+
+  for (char c : name) {
+    if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_')) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 namespace fs = std::filesystem;
 
@@ -86,6 +100,13 @@ int main(int argc, char** argv) {
 
   std::string arg = argv[1];
 
+  if (!is_valid_project_name(arg)) {
+    std::cerr << "Error: invalid project name '" << arg << "'.\n"
+              << "Project names must be 1–64 characters long and contain only "
+              << "letters, numbers, hyphens, or underscores.\n";
+    return 1;
+  }
+
   if (arg == "--help") {
     print_help(argv[0]);
     return 0;
@@ -101,11 +122,11 @@ int main(int argc, char** argv) {
   fs::create_directories(arg + "/tests");
 
   // create files replacing project name
-  std::ofstream(arg + "/src/main.cpp") << replace_project_name(main_template, project);
-  std::ofstream(arg + "/CMakeLists.txt") << replace_project_name(cmake_template, project);
-  std::ofstream(arg + "/README.md") << replace_project_name(readme_template, project);
-  std::ofstream(arg + "/.gitignore") << replace_project_name(gitignore_template, project);
-  std::ofstream(arg + "/tests/test.cpp") << replace_project_name(test_template, project);
+  std::ofstream(arg + "/src/main.cpp") << replace_project_name(main_template, arg);
+  std::ofstream(arg + "/CMakeLists.txt") << replace_project_name(cmake_template, arg);
+  std::ofstream(arg + "/README.md") << replace_project_name(readme_template, arg);
+  std::ofstream(arg + "/.gitignore") << replace_project_name(gitignore_template, arg);
+  std::ofstream(arg + "/tests/test.cpp") << replace_project_name(test_template, arg);
 
   std::cout << "Project created successfully: " << arg << std::endl;
   std::cout << "Run 'cd " << arg << " && cmake .. && make' to build the project." << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,14 +21,6 @@ void print_version() {
   std::cout << "smith version: " << SMITH_VERSION << std::endl;
 }
 
-bool write_file(const std::string& path, const std::string& contents) {
-  std::ofstream out(path);
-  if (!out) {
-    return false;
-  }
-  out << contents;
-  return static_cast<bool>(out);
-}
 
 namespace fs = std::filesystem;
 
@@ -104,20 +96,19 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  std::string project = argv[1];
-  fs::create_directories(project + "/src");
-  fs::create_directories(project + "/include");
-  fs::create_directories(project + "/tests");
+  fs::create_directories(arg + "/src");
+  fs::create_directories(arg + "/include");
+  fs::create_directories(arg + "/tests");
 
   // create files replacing project name
-  std::ofstream(project + "/src/main.cpp") << replace_project_name(main_template, project);
-  std::ofstream(project + "/CMakeLists.txt") << replace_project_name(cmake_template, project);
-  std::ofstream(project + "/README.md") << replace_project_name(readme_template, project);
-  std::ofstream(project + "/.gitignore") << replace_project_name(gitignore_template, project);
-  std::ofstream(project + "/tests/test.cpp") << replace_project_name(test_template, project);
+  std::ofstream(arg + "/src/main.cpp") << replace_project_name(main_template, project);
+  std::ofstream(arg + "/CMakeLists.txt") << replace_project_name(cmake_template, project);
+  std::ofstream(arg + "/README.md") << replace_project_name(readme_template, project);
+  std::ofstream(arg + "/.gitignore") << replace_project_name(gitignore_template, project);
+  std::ofstream(arg + "/tests/test.cpp") << replace_project_name(test_template, project);
 
-  std::cout << "Project created successfully: " << project << std::endl;
-  std::cout << "Run 'cd " << project << " && cmake .. && make' to build the project." << std::endl;
+  std::cout << "Project created successfully: " << arg << std::endl;
+  std::cout << "Run 'cd " << arg << " && cmake .. && make' to build the project." << std::endl;
 
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,33 @@
 #include <iostream>
 #include <string>
 
+//Change when updating smith
+constexpr const char* SMITH_VERSION = "0.1.0";
+
+void print_help(const char* program_name) {
+  std::cout
+    << "Usage:\n"
+    << "  " << program_name << " ProjectName\n"
+    << "  " << program_name << " --help\n"
+    << "  " << program_name << " --version\n\n"
+    << "Options:\n"
+    << "  --help      Show this help message\n"
+    << "  --version   Print version information\n";
+}
+
+void print_version() {
+  std::cout << "smith version: " << SMITH_VERSION << std::endl;
+}
+
+bool write_file(const std::string& path, const std::string& contents) {
+  std::ofstream out(path);
+  if (!out) {
+    return false;
+  }
+  out << contents;
+  return static_cast<bool>(out);
+}
+
 namespace fs = std::filesystem;
 
 // built in templates
@@ -61,8 +88,20 @@ std::string replace_project_name(const std::string& template_string, const std::
 
 int main(int argc, char** argv) {
   if (argc < 2) {
-    std::cerr << "Usage: " << argv[0] << " ProjectName" << std::endl;
+    print_help(argv[0]);
     return 1;
+  }
+
+  std::string arg = argv[1];
+
+  if (arg == "--help") {
+    print_help(argv[0]);
+    return 0;
+  }
+
+  if (arg == "--version") {
+    print_version();
+    return 0;
   }
 
   std::string project = argv[1];


### PR DESCRIPTION
## Summary

I added validation for project names to prevent invalid paths and broken CMake configurations.  
Projects names have to now be between 1-64 character and contain only letters, numbers, hyphens, or underscores.

## Issues

Fixed  #7 